### PR TITLE
Add line separator at output start

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -141,7 +141,7 @@ export default class SizePlugin {
 			output += msg + sizeText + '\n';
 		}
 		if (output) {
-			console.log(output);
+			console.log('\n' + output);
 		}
 	}
 


### PR DESCRIPTION
Without leading line seperator output looks like this for me using vue-cli:
![image](https://user-images.githubusercontent.com/7964583/49868646-15eb8d00-fe1f-11e8-88cf-5e1831aea1f0.png)
